### PR TITLE
Exports from plurals.js missing

### DIFF
--- a/lib/plurals.js
+++ b/lib/plurals.js
@@ -1,5 +1,5 @@
 // definition http://translate.sourceforge.net/wiki/l10n/pluralforms
-var pluralExtensions = {
+module.exports = {
 
     rules: {
         "ach": {


### PR DESCRIPTION
when i run the current version from npm:

```
➜  mobile2 git:(master) ✗ i18next-conv -l de -s locales/de/translation.json -t locales/de/translation.po

start converting

    --> reading file from: locales/de/translation.json

/usr/local/lib/node_modules/i18next-conv/lib/gettextWrapper.js:93
        var ext = plurals.rules[domain.split('-')[0]];
                               ^
TypeError: Cannot read property 'de' of undefined
    at Object.parseGettext (/usr/local/lib/node_modules/i18next-conv/lib/gettextWrapper.js:93:32)
    at /usr/local/lib/node_modules/i18next-conv/lib/gettextWrapper.js:58:18
    at /usr/local/lib/node_modules/i18next-conv/lib/gettextWrapper.js:82:13
    at [object Object].<anonymous> (fs.js:115:5)
    at [object Object].emit (events.js:64:17)
    at afterRead (fs.js:1117:12)
    at Object.wrapper [as oncomplete] (fs.js:254:17)
```

adding exports to plurals.js fixes this. code attached.
