### PR TITLE
--quiet option to suppress output

### DIFF
--- a/lib/gettextWrapper.js
+++ b/lib/gettextWrapper.js
@@ -55,11 +55,11 @@ module.exports = {
         self.flattenI18nextJSON(source, options, function(err, flat) {
             //self.writeFile('./' + path.join(dirname, filename + '_tmp.json'), JSON.stringify(flat, null, 4), function(){});
 
-            self.parseGettext(domain, flat, function(err, gt) {
+            self.parseGettext(domain, flat, options, function(err, gt) {
 
                 var data = path.extname(target) === '.po' ? gt.compilePO(domain) : gt.compileMO(domain);
 
-                self.writeFile(target, data, callback);
+                self.writeFile(target, data, options, callback);
             });
         });
     },
@@ -70,7 +70,8 @@ module.exports = {
     flattenI18nextJSON: function(source, options, callback) {
         var self = this;
 
-        console.log(('\n    --> reading file from: ' + source));
+        if (!options.quiet) console.log(('\n    --> reading file from: ' + source));
+
         fs.readFile(source, function(err, body) {
             if(err) {
                 callback(err);
@@ -86,13 +87,13 @@ module.exports = {
     /* flat json --> gettext
      *
      */
-    parseGettext: function(domain, data, callback) {
+    parseGettext: function(domain, data, options, callback) {
         var gt = new Gettext();
         gt.addTextdomain(domain, '');
 
         var ext = plurals.rules[domain.split('-')[0]];
 
-        console.log('\n    <-> parsing data to gettext format'.cyan);
+        if (!options.quiet) console.log('\n    <-> parsing data to gettext format'.cyan);
 
         for (var m in data) {
             var kv = data[m];
@@ -179,14 +180,14 @@ module.exports = {
             if (!fs.statSync(dir)) fs.mkdirSync(dir);
         }
 
-        self.addTextDomain(domain, source, function(err, data) {
+        self.addTextDomain(domain, source, options, function(err, data) {
             // console.log(data);
 
             self.parseJSON(domain, data, options, function(err, json) {
                 var jsonData = JSON.stringify(json, null, 4);
                 // console.log(jsonData);
 
-                self.writeFile(target, jsonData, callback);
+                self.writeFile(target, jsonData, options, callback);
             });
         });
     },
@@ -194,10 +195,11 @@ module.exports = {
     /* gettext --> barebone json
      *
      */
-    addTextDomain: function(domain, source, callback) {
+    addTextDomain: function(domain, source, options, callback) {
         var self = this;
 
-        console.log(('\n    --> reading file from: ' + source));
+        if (!options.quiet) console.log(('\n    --> reading file from: ' + source));
+
         fs.readFile(source, function(err, body) {
             if(err) {
                 callback(err);
@@ -311,9 +313,9 @@ module.exports = {
     * SHARED
     *
     ***************************/
-    writeFile: function(target, data, callback) {
+    writeFile: function(target, data, options, callback) {
 
-        console.log(('\n    <-- writting file to: ' + target));
+        if (!options.quiet) console.log(('\n    <-- writting file to: ' + target));
         fs.writeFile(target, data, function(err) {
             callback(err);
         });

--- a/program.js
+++ b/program.js
@@ -23,19 +23,21 @@ program
   .option('-t, --target [path]', 'Specify path to write to', '')
   .option('-l, --language [domain]', 'Specify the language code, eg. \'en\'')
   .option('-ks, --keyseparator [path]', 'Specify keyseparator you want to use, defaults to ##', '##')
+  .option('--quiet', 'Silence output', false)
   .parse(process.argv);
 
 if (program.source && program.language) {
-	console.log('\nstart converting'.yellow);
-
 	var options = {
-		keyseparator: program.keyseparator
+		keyseparator: program.keyseparator,
+		quiet: program.quiet
 	};
+
+	if (!options.quiet) console.log('\nstart converting'.yellow);
 
 	converter.process(program.language, program.source, program.target, options, function(err) {
 		if (err) {
 			console.log('\nfailed writing file\n\n'.red);
-		} else {
+		} else if (!options.quiet) {
 			console.log('\nfile written\n\n'.green);
 		}
 	});


### PR DESCRIPTION
I added a `--quiet` option to `i18next-conv` to suppress its output. We're experimenting with integrating i18next with our build system, and needed to remove the output caused by the convertor.

If you would like any changes to the commit, let me know.
