### PR TITLE
add --plurals option to load module file with custom plurals definition

### DIFF
--- a/lib/gettextWrapper.js
+++ b/lib/gettextWrapper.js
@@ -12,6 +12,12 @@ module.exports = {
     process: function(domain, source, target, options, callback) {
         var ext = path.extname(source);
 
+        if (options.plurals) {
+                plurals_path = path.join(process.cwd(), options.plurals);
+                plurals.rules = require(plurals_path);
+                if (!options.quiet) console.log(('\nuse custom plural forms ' + plurals_path + '\n').blue);
+        }
+
         if (ext === '.mo' || ext === '.po') {
             return this.gettextToI18next(domain, source, target, options, callback);
         }

--- a/program.js
+++ b/program.js
@@ -23,12 +23,14 @@ program
   .option('-t, --target [path]', 'Specify path to write to', '')
   .option('-l, --language [domain]', 'Specify the language code, eg. \'en\'')
   .option('-ks, --keyseparator [path]', 'Specify keyseparator you want to use, defaults to ##', '##')
+  .option('-P, --plurals [path]', 'Specify path to plural forms definitions')
   .option('--quiet', 'Silence output', false)
   .parse(process.argv);
 
 if (program.source && program.language) {
 	var options = {
 		keyseparator: program.keyseparator,
+		plurals: program.plurals,
 		quiet: program.quiet
 	};
 


### PR DESCRIPTION
Example of plural definition module.

var plurals = module.parent.require("./plurals");
module.exports = plurals.rules;
module.exports.dev = modeule.exports.en;
