### PR TITLE
fix wrong index when path name contains the domain

### DIFF
--- a/lib/gettextWrapper.js
+++ b/lib/gettextWrapper.js
@@ -55,7 +55,7 @@ module.exports = {
 
         if (!target) {
             var dir;
-            if (dirname.indexOf(domain) === dirname.length - domain.length) {
+            if (dirname.lastIndexOf(domain) === dirname.length - domain.length) {
                 dir = path.join(dirname);
                 target = path.join(dirname, filename + '.po');
             } else {
@@ -194,7 +194,7 @@ module.exports = {
 
         if (!target) {
             var dir;
-            if (dirname.indexOf(domain) === dirname.length - domain.length) {
+            if (dirname.lastIndexOf(domain) === dirname.length - domain.length) {
                 dir = path.join(dirname);
                 target = path.join(dirname, filename + '.json');
             } else {


### PR DESCRIPTION
dirname.indexOf(domain) returns wrong index when the domain is earlier in the path, e.g.
dev/.../de/translation.json returns index 0 instead of 8
using lastIndexOf fixes the problem