### PR TITLE
Update node-gettext to ^1.0.1, which is node only

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "colors": "^1.0.3",
     "commander": "^2.5.0",
     "mkdirp": "^0.5.0",
-    "node-gettext": "^0.2.14"
+    "node-gettext": "^1.0.1"
   },
   "devDependencies": {
     "async": "^0.9.0",


### PR DESCRIPTION
The old `node-gettext` has a dependency on `iconv` which is dependant on non-JavaScript libraries.