### PR TITLE
Set the original strings if missing in PO

### DIFF
--- a/lib/gettextWrapper.js
+++ b/lib/gettextWrapper.js
@@ -293,6 +293,12 @@ module.exports = {
 			    data[ctxt][key].comments.reference.split(/\r?\n|\r/).forEach(function(id) {
 				var x = data[ctxt][key];
 				data[ctxt][id] = x;
+				if (x.msgstr[0] === '')
+				    x.msgstr[0] = x.msgid;
+				for (var i = 1; i < x.msgstr.length; i++) {
+				    if (x.msgstr[i] === '')
+					x.msgstr[i] = x.msgid_plural;
+                                }
 				x.msgid = id;
 				if (id !== key)
 				    keys.push([ctxt, key]);

--- a/test/_testfiles/de/translation.utf8_msgid_not_fully_translated.json
+++ b/test/_testfiles/de/translation.utf8_msgid_not_fully_translated.json
@@ -1,0 +1,15 @@
+{
+    "name": "name",
+    "name-õäöü": "t3-žš",
+    "a": {
+        "apple": "Ich habe einen Apfel",
+        "apple_plural": "Ich habe {count} Äpfel",
+        "apple_negative": "I have no apples"
+    },
+    "friend": "Freund",
+    "friend_plural": "{count} Freunde",
+    "friend_male": "A boyfriend",
+    "friend_male_plural": "{count} boyfriends",
+    "friend_female": "A girlfriend",
+    "friend_female_plural": "{count} girlfriends"
+}

--- a/test/_testfiles/de/translation.utf8_msgid_not_fully_translated.po
+++ b/test/_testfiles/de/translation.utf8_msgid_not_fully_translated.po
@@ -1,0 +1,46 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: i18next-conv\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1)\n"
+
+#: name
+msgid "name"
+msgstr "name"
+
+#: name-õäöü
+msgid "t3-žš"
+msgstr "t3-žš"
+
+#: a##apple
+msgid "I have an apple"
+msgid_plural "I have {count} apples"
+msgstr[0] "Ich habe einen Apfel"
+msgstr[1] "Ich habe {count} Äpfel"
+
+#: friend
+msgid "Friend"
+msgid_plural "{count} friends"
+msgstr[0] "Freund"
+msgstr[1] "{count} Freunde"
+
+#: a##apple
+msgctxt "negative"
+msgid "I have no apples"
+msgstr ""
+
+#: friend
+msgctxt "male"
+msgid "A boyfriend"
+msgid_plural "{count} boyfriends"
+msgstr[0] ""
+msgstr[1] ""
+
+#: friend
+msgctxt "female"
+msgid "A girlfriend"
+msgid_plural "{count} girlfriends"
+msgstr[0] ""
+msgstr[1] ""

--- a/test/_testfiles/ru/translation.utf8_msgid_not_fully_translated.json
+++ b/test/_testfiles/ru/translation.utf8_msgid_not_fully_translated.json
@@ -1,0 +1,16 @@
+{
+    "a": {
+        "apple_1": "У меня есть яблоко",
+        "apple_2": "У меня {count} яблока",
+        "apple_5": "У меня {count} яблок"
+    },
+    "friend_1": "Friend",
+    "friend_2": "{count} друга",
+    "friend_5": "{count} друзей",
+    "friend_male_1": "Парень",
+    "friend_male_2": "{count} boyfriends",
+    "friend_male_5": "{count} парней",
+    "friend_female_1": "Подруга",
+    "friend_female_2": "{count} подруги",
+    "friend_female_5": "{count} girlfriends"
+}

--- a/test/_testfiles/ru/translation.utf8_msgid_not_fully_translated.po
+++ b/test/_testfiles/ru/translation.utf8_msgid_not_fully_translated.po
@@ -1,0 +1,38 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: i18next-conv\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2)\n"
+
+#: a##apple
+msgid "I have an apple"
+msgid_plural "I have {count} apples"
+msgstr[0] "У меня есть яблоко"
+msgstr[1] "У меня {count} яблока"
+msgstr[2] "У меня {count} яблок"
+
+#: friend
+msgid "Friend"
+msgid_plural "{count} friends"
+msgstr[0] ""
+msgstr[1] "{count} друга"
+msgstr[2] "{count} друзей"
+
+#: friend
+msgctxt "male"
+msgid "A boyfriend"
+msgid_plural "{count} boyfriends"
+msgstr[0] "Парень"
+msgstr[1] ""
+msgstr[2] "{count} парней"
+
+#: friend
+msgctxt "female"
+msgid "A girlfriend"
+msgid_plural "{count} girlfriends"
+msgstr[0] "Подруга"
+msgstr[1] "{count} подруги"
+msgstr[2] ""

--- a/test/gettextWrapper.test.js
+++ b/test/gettextWrapper.test.js
@@ -28,13 +28,17 @@ var testFiles = {
 	utf8_expected: './test/_testfiles/de/translation.utf8.json',
 	utf8_msgid: './test/_testfiles/de/translation.utf8_msgid.po',
 	utf8_msgid_expected: './test/_testfiles/de/translation.utf8_msgid.json',
+	utf8_msgid_not_fully_translated: './test/_testfiles/de/translation.utf8_msgid_not_fully_translated.po',
+	utf8_msgid_not_fully_translated_expected: './test/_testfiles/de/translation.utf8_msgid_not_fully_translated.json'
     },
 
     ru: {
 	utf8: './test/_testfiles/ru/translation.utf8.po',
 	utf8_expected: './test/_testfiles/ru/translation.utf8.json',
 	utf8_2: './test/_testfiles/ru/translation2.utf8.po',
-	utf8_2_expected: './test/_testfiles/ru/translation2.utf8.json'
+	utf8_2_expected: './test/_testfiles/ru/translation2.utf8.json',
+	utf8_msgid_not_fully_translated: './test/_testfiles/ru/translation.utf8_msgid_not_fully_translated.po',
+	utf8_msgid_not_fully_translated_expected: './test/_testfiles/ru/translation.utf8_msgid_not_fully_translated.json'
     }
 };
 
@@ -219,6 +223,34 @@ describe('the gettext wrapper', function() {
 		});
 	    });
 	    async.series(tests, done);
+	});
+
+	it('should fill in the original English strings if missing - convert a utf8 PO file with msgid as original string to a JSON file', function(done) {
+		var tests = [];
+
+		// DE
+		tests.push(function(next) {
+			var output = './test/_tmp/de_utf8_msgid_not_fully_translated.json';
+			wrapper.gettextToI18next('de', testFiles.de.utf8_msgid_not_fully_translated, output, {quiet: true, splitNewLine: true, keyasareference: true}, function() {
+				var result = require(path.join('..', output));
+				var expected = require(path.join('..', testFiles.de.utf8_msgid_not_fully_translated_expected));
+				expect(result).to.deep.equal(expected);
+				fs.unlinkSync(output);
+				next();
+	                });
+		});
+		// RU
+		tests.push(function(next) {
+			var output = './test/_tmp/ru_utf8_msgid_not_fully_translated.json';
+			wrapper.gettextToI18next('ru', testFiles.ru.utf8_msgid_not_fully_translated, output, {quiet: true, splitNewLine: true, keyasareference: true}, function() {
+				var result = require(path.join('..', output));
+				var expected = require(path.join('..', testFiles.ru.utf8_msgid_not_fully_translated_expected));
+				expect(result).to.deep.equal(expected);
+				fs.unlinkSync(output);
+				next();
+	                });
+		});
+		async.series(tests, done);
 	});
 
 	// -- Error States & Invalid Data --


### PR DESCRIPTION
Set the original strings if missing translations in PO and converting it with --keyasareference option.
Unlike an usual gettext applications, this sort of apps expects to see strings in JSON regardless of i18n.
So if JSON is missing strings, that may ends up to show no strings.
This change will fixes such issue.