### PR TITLE
Fix bug gettext header "plurals" for zero rule

### DIFF
--- a/lib/gettextWrapper.js
+++ b/lib/gettextWrapper.js
@@ -149,7 +149,7 @@ module.exports = {
 	var trans = {};
 	var plural_func = '' + ext.plurals;
 
-	out['headers']['plural-forms'] = 'nplurals=' + ext.numbers.length + '; plural=' + plural_func.replace(/^function ?\(n\) ?\{ ?return ?/, '').replace(/; }$/, '');
+	out['headers']['plural-forms'] = 'nplurals=' + ext.numbers.length + '; plural=' + plural_func.replace(/^function ?\(n\) ?\{ ?return (Number)?/, '').replace(/; }$/, '');
 	if (!options.noDate) {
 	    out['headers']['pot-creation-date'] = new Date().toISOString();
 	    out['headers']['po-revision-date'] = new Date().toISOString();

--- a/lib/gettextWrapper.js
+++ b/lib/gettextWrapper.js
@@ -149,7 +149,7 @@ module.exports = {
 	var trans = {};
 	var plural_func = '' + ext.plurals;
 
-	out['headers']['plural-forms'] = 'nplurals=' + ext.numbers.length + '; plural=' + plural_func.replace(/^function \(n\) \{ return Number/, '').replace(/; }$/, '');
+	out['headers']['plural-forms'] = 'nplurals=' + ext.numbers.length + '; plural=' + plural_func.replace(/^function ?\(n\) ?\{ ?return ?/, '').replace(/; }$/, '');
 	if (!options.noDate) {
 	    out['headers']['pot-creation-date'] = new Date().toISOString();
 	    out['headers']['po-revision-date'] = new Date().toISOString();


### PR DESCRIPTION
PO header is displaying a wrong _plural_ value:
```
"Plural-Forms: nplurals=1; plural=function (n) { return 0\n"
```
Expected:
```
"Plural-Forms: nplurals=1; plural=0\n"
```