### PR TITLE
Use file paths when converting .json to .po

### DIFF
--- a/src/lib/flatten.js
+++ b/src/lib/flatten.js
@@ -75,6 +75,16 @@ module.exports = {
             context,
           };
           appendTo[appendKey] = kv;
+        } else if (typeof value === 'object' && typeof value.msgstr === 'string' && Array.isArray(value.paths)) {
+          kv = {
+            key,
+            value: value.msgstr,
+            isPlural,
+            pluralNumber: isPlural ? number : 0,
+            context,
+            paths: value.paths,
+          };
+          appendTo[appendKey] = kv;
         } else if (Array.isArray(value)) {
           kv = {
             // id: key.replace(new RegExp(' ', 'g'), ''),

--- a/test/_testfiles/en/translation.file_paths.json
+++ b/test/_testfiles/en/translation.file_paths.json
@@ -1,0 +1,25 @@
+{
+  " ": {
+    "msgstr": "white space test",
+    "paths": ["fake/path/index.html"]
+  },
+  "yasss queen": {
+    "msgstr": "",
+    "paths": ["fake/path/template.hbs", "fake/path/partial.hbs"]
+  },
+  "a": {
+    "apple": {
+      "msgstr": "I have an apple",
+      "paths": ["./test/fakepath/zero.jade", "./test/fakepath/one.jade", "./test/fakepath/two.jade"]
+    },
+    "apple_plural": "I have {count} apples",
+    "apple_negative": "I have no apples"
+  },
+  "friend_female": {
+    "msgstr": "A girlfriend",
+    "paths": ["./test/_testfiles/en/translation.file_paths.json"]
+  },
+  "friend_female_plural": "{count} girlfriends",
+  "friend_nonbinary": "A partner",
+  "friend_nonbinary_plural": "{count} partners"
+}

--- a/test/_testfiles/en/translation.file_paths.po
+++ b/test/_testfiles/en/translation.file_paths.po
@@ -1,0 +1,41 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: i18next-conv\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1)\n"
+
+#: fake/path/index.html
+msgid " "
+msgstr "white space test"
+
+#: fake/path/template.hbs
+#: fake/path/partial.hbs
+msgid "yasss queen"
+msgstr ""
+
+#: ./test/fakepath/zero.jade
+#: ./test/fakepath/one.jade
+#: ./test/fakepath/two.jade
+msgid "a##apple"
+msgid_plural "a##apple"
+msgstr[0] "I have an apple"
+msgstr[1] "I have {count} apples"
+
+msgctxt "negative"
+msgid "a##apple"
+msgstr "I have no apples"
+
+#: ./test/_testfiles/en/translation.file_paths.json
+msgctxt "female"
+msgid "friend"
+msgid_plural "friend"
+msgstr[0] "A girlfriend"
+msgstr[1] "{count} girlfriends"
+
+msgctxt "nonbinary"
+msgid "friend"
+msgid_plural "friend"
+msgstr[0] "A partner"
+msgstr[1] "{count} partners"

--- a/test/index.js
+++ b/test/index.js
@@ -31,6 +31,8 @@ const testFiles = {
     empty: './test/_testfiles/en/translation.empty.po',
     missing: './test/_testfiles/en/translation.missing.po',
     bad_format: './test/_testfiles/en/translation.bad_format.po.js',
+    file_paths: './test/_testfiles/en/translation.file_paths.po',
+    file_paths_expected: './test/_testfiles/en/translation.file_paths.json',
   },
 
   de: {
@@ -266,6 +268,16 @@ describe('i18next-gettext-converter', () => {
           expect(result).to.deep.equal(expected);
         }),
       ])
+    );
+
+    it('should convert a JSON file to PO with comments from file paths', () =>
+      i18nextToPo('en', readFileSync(testFiles.en.file_paths_expected), {
+        splitNewLine: true,
+        noDate: true,
+      }).then(result => {
+        const expected = readFileSync(testFiles.en.file_paths).slice(0, -1);
+        expect(result).to.deep.equal(expected);
+      })
     );
   });
 


### PR DESCRIPTION
This PR adds the capability, when converting from .json to .po, to add comments to the .po file with the file path information for where strings were found. This special format of the i18next .json (as described in [the PR](https://github.com/i18next/i18next-parser/pull/56) which implements it) can be optionally output by the i18next-parser by including `--track-paths true`. Converting from the original .json format should remain unaffected, as these changes make it possible to mix formats dynamically, adding file path comments when available and leaving them out when not available.

fixes #55 
