### PR TITLE
[fix] Use UTF-8 as defaultCharset for gettext-parser

### DIFF
--- a/src/lib/gettext2json.js
+++ b/src/lib/gettext2json.js
@@ -25,7 +25,7 @@ function addTextDomain(locale, body, options = {}) {
   const domain = 'messages';
 
   if (body.length > 0) {
-    gt.addTranslations(locale, domain, po.parse(body));
+    gt.addTranslations(locale, domain, po.parse(body, 'UTF-8'));
   }
 
   if (options.filter) {


### PR DESCRIPTION
The old version 3.0.3 is able to support UTF-8 encoded po files automatically, but after upgrade to 4.0.3, UTF-8 files are corrupted and I think it's because the use of gettext-parser in `gettext2json.js`, and defaultCharset is not setting correctly.

Just FYI.