### PR TITLE
Bring Portuguese plurals in line with i18next and CLDR

### DIFF
--- a/src/lib/gettext2json.js
+++ b/src/lib/gettext2json.js
@@ -131,7 +131,7 @@ function getGettextValues(values, locale, targetKey, options) {
     return emptyOrObject(targetKey, values[0], options);
   }
 
-  const ext = plurals.rules[locale.replace('_', '-').split('-')[0]];
+  const ext = plurals.getRule(locale);
   const gettextValues = {};
 
   for (let i = 0; i < values.length; i += 1) {

--- a/src/lib/json2gettext.js
+++ b/src/lib/json2gettext.js
@@ -67,7 +67,7 @@ function parseGettext(domain, data, options = {}) {
     translations: {},
   };
 
-  const ext = plurals.rules[domain.replace('_', '-').split('-')[0]];
+  const ext = plurals.getRule(domain);
   const trans = {};
 
   out.headers['plural-forms'] =

--- a/src/lib/plurals.js
+++ b/src/lib/plurals.js
@@ -487,14 +487,14 @@ module.exports = {
       plurals: '(n != 1)',
     },
     pt: {
-      name: 'Portuguese',
-      nplurals: 2,
-      plurals: '(n != 1)',
-    },
-    pt_br: {
-      name: 'Brazilian Portuguese',
+      name: 'Portuguese', // according to http://www.unicode.org/cldr/charts/26/supplemental/language_plural_rules.html#pt
       nplurals: 2,
       plurals: '(n > 1)',
+    },
+    pt_pt: {
+      name: 'European Portuguese',
+      nplurals: 2,
+      plurals: '(n != 1)',
     },
     rm: {
       name: 'Romansh',
@@ -661,5 +661,9 @@ module.exports = {
       nplurals: 1,
       plurals: '0',
     },
+  },
+  getRule(code) {
+    const locale = code.replace('-', '_');
+    return this.rules[locale.toLowerCase()] || this.rules[locale.split('_')[0]];
   },
 };

--- a/test/index.js
+++ b/test/index.js
@@ -271,6 +271,21 @@ describe('i18next-gettext-converter', () => {
         }),
       ])
     ));
+
+    describe('should return the correct plural forms for Portuguese', () => {
+      [
+        ['pt-PT', 'plural=(n != 1)'], // pt-PT = European Portuguese = nplurals=2; plural=(n != 1);
+        ['pt-BR', 'plural=(n > 1)'], // pt-BR = Brazillian Portuguese = nplurals=2; plural=(n > 1);
+        ['pt-br', 'plural=(n > 1)'], // pt-BR === pt-br
+        ['pt', 'plural=(n > 1)'], // pt = Portuguese (catch all) == pt-BR == plural=(n > 1);
+      ].forEach(([code, plural]) => {
+        it(`${code} should have ${plural}`, () => (
+          i18nextToPo(code, '{}').then((result) => {
+            expect(result.toString()).to.include(`Plural-Forms: nplurals=2; ${plural}`);
+          })
+        ));
+      });
+    });
   });
 
   describe('the functions', () => {


### PR DESCRIPTION
This PR addresses #67 and takes the same approach as the associated `i18next` fix https://github.com/i18next/i18next/commit/c5113fb62326155e671def12bc7386f44643b0d1

The plural forms for Portuguese have been changed.
Now `pt-PT` is the exception to the rule, taking `plural=(n != 1)` where as all other forms of Portuguese (including `pt` and `pt-BR`) take `plural=(n > 1)`. This is in accordance with the Unicode spec for [Portuguese (`pt`)](http://www.unicode.org/cldr/charts/26/supplemental/language_plural_rules.html#pt) and [European Portuguese (`pt-PT`)](http://www.unicode.org/cldr/charts/26/supplemental/language_plural_rules.html#pt_PT).

For `i18next` this was seen as a breaking change and bumped a major.