### PR TITLE
Remove pkginfo usage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4529,11 +4529,6 @@
         }
       }
     },
-    "pkginfo": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.4.1.tgz",
-      "integrity": "sha1-tUGO8EOd5UJfxJlQQtztFPsqhP8="
-    },
     "pluralize": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -27,8 +27,7 @@
     "gettext-parser": "^1.3.0",
     "mkdirp": "^0.5.1",
     "node-gettext": "^2.0.0",
-    "object-assign": "^4.1.1",
-    "pkginfo": "^0.4.1"
+    "object-assign": "^4.1.1"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -1,4 +1,4 @@
-const pkginfo = require('pkginfo');
+const { version } = require('../../package.json');
 const gettextToI18next = require('./gettext2json');
 const {
   i18nextToPo,
@@ -11,6 +11,5 @@ module.exports = {
   i18nextToPo,
   i18nextToPot,
   i18nextToMo,
+  version,
 };
-
-pkginfo(module, ['version']);

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -1,4 +1,3 @@
-const { version } = require('../../package.json');
 const gettextToI18next = require('./gettext2json');
 const {
   i18nextToPo,
@@ -11,5 +10,4 @@ module.exports = {
   i18nextToPo,
   i18nextToPot,
   i18nextToMo,
-  version,
 };


### PR DESCRIPTION
This dependency seems to be causing a few problems when used with webpack.
Considering what it's doing, I think it's not such a bad thing to just use node to do it, unless you used it for specific reasons which I didn't manage to uncover looking at the history of the project.