### PR TITLE
Correctly handle the `base` CLI argument

### DIFF
--- a/src/bin/index.js
+++ b/src/bin/index.js
@@ -61,6 +61,7 @@ const {
   source,
   target,
   filter,
+  base: baseArg,
   ...options
 } = program;
 
@@ -68,8 +69,8 @@ if (filter && fs.existsSync(filter)) {
   options.filter = require(filter); // eslint-disable-line global-require,import/no-dynamic-require
 }
 
-if (base && fs.existsSync(base)) {
-  options.base = fs.readFileSync(base);
+if (baseArg && fs.existsSync(baseArg)) {
+  options.base = fs.readFileSync(baseArg);
 }
 
 const {


### PR DESCRIPTION
POT file generation is not currently working, without any visible error. For example:
```
» ./node_modules/.bin/i18next-conv -l en -s i18n/en/translation.json -t i18n/template.pot -p -b i18n/en/translation.json -K
start converting
--> reading file from: i18n/en/translation.json
file written
```

This happens because `options.base` is currently set as the file path, not the file contents (see the commit, `base` was not defined, thus the option not replaced by the file content).
This fails silently in `JSON.parse` here: https://github.com/i18next/i18next-gettext-converter/blob/b49e88ccbcdecf5c342de1844aa944fbeb957a54/src/lib/json2gettext.js#L23
I did not investigate why no error is displayed, I guess the exception is catched somewhere and not correctly handled.