### PR TITLE
respect skipUntranslated option when used with keyasareference option

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "i18next-conv",
-  "version": "6.0.1",
+  "version": "6.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/lib/gettext2json.js
+++ b/src/lib/gettext2json.js
@@ -8,7 +8,7 @@ function gettextToI18next(locale, body, options = {}) {
   return addTextLocale(locale, body, options)
     .then((data) => {
       if (options.keyasareference) {
-        setKeysAsReference(data);
+        setKeysAsReference(data, options);
       }
 
       return parseJSON(locale, data, options);
@@ -39,7 +39,7 @@ function addTextLocale(locale, body, options = {}) {
   return Promise.resolve(gt.catalogs[locale] && gt.catalogs[locale][domain].translations);
 }
 
-function setKeysAsReference(data) {
+function setKeysAsReference(data, options) {
   const keys = [];
 
   Object.keys(data).forEach((ctxt) => {
@@ -48,6 +48,10 @@ function setKeysAsReference(data) {
         data[ctxt][key].comments.reference.split(/\r?\n|\r/).forEach((id) => {
           const x = data[ctxt][key];
           data[ctxt][id] = x;
+
+          if (options.skipUntranslated && x.msgstr.length === 1 && !x.msgstr[0]) {
+            return;
+          }
 
           if (x.msgstr[0] === '') {
             x.msgstr[0] = x.msgid;

--- a/test/index.js
+++ b/test/index.js
@@ -203,6 +203,18 @@ describe('i18next-gettext-converter', () => {
       ])
     ));
 
+    it('should skip empty values appropriately even when using key as reference', () => (
+      Promise.all([
+        gettextToI18next('en', readFileSync(testFiles.en.untranslated), {
+          keyasareference: true,
+          skipUntranslated: true,
+        }).then((result) => {
+          const expected = requireTestFile(testFiles.en.untranslated_skipped);
+          expect(JSON.parse(result)).to.deep.equal(expected);
+        }),
+      ])
+    ));
+
     // -- Error States & Invalid Data --
 
     describe('error states', () => {


### PR DESCRIPTION
Fix a bug when using both --keyasareference and --skipUntranslated options it doesn't respect the --skipUntranslated option.