### PR TITLE
Updated Hebrew plurals

### DIFF
--- a/src/lib/plurals.js
+++ b/src/lib/plurals.js
@@ -1,4 +1,5 @@
 // definition http://translate.sourceforge.net/wiki/l10n/pluralforms
+// Hebrew (he) updated in line with https://github.com/i18next/i18next/pull/1121
 module.exports = {
   rules: {
     ach: {
@@ -233,8 +234,8 @@ module.exports = {
     },
     he: {
       name: 'Hebrew',
-      nplurals: 2,
-      plurals: '(n != 1)',
+      nplurals: 4,
+      plurals: '(n===1 ? 0 : n===2 ? 1 : (n<0 || n>10) && n%10==0 ? 2 : 3)',
     },
     hi: {
       name: 'Hindi',

--- a/test/index.js
+++ b/test/index.js
@@ -284,6 +284,13 @@ describe('i18next-gettext-converter', () => {
       ])
     ));
 
+    it('should return correct nplurals for Hebrew', () => (
+      i18nextToPo('he', '{}').then((result) => {
+        const oneLine = result.toString().replace(/\n/g, ' ').replace(/"/g, '');
+        expect(oneLine).to.include('Plural-Forms: nplurals=4; plural=(n===1 ? 0 : n===2 ? 1 : (n<0 || n>10) &&  n%10==0 ? 2 : 3)');
+      })
+    ));
+
     describe('should return the correct plural forms for Portuguese', () => {
       [
         ['pt-PT', 'plural=(n != 1)'], // pt-PT = European Portuguese = nplurals=2; plural=(n != 1);


### PR DESCRIPTION
In line with https://github.com/i18next/i18next/pull/1121 and i18next `v12.0.0` I have updated the plural rules for Hebrew to match those used by i18next's `PluralResolver`.