### PR TITLE
Fix: using an external filter module from the command line

### DIFF
--- a/src/bin/index.js
+++ b/src/bin/index.js
@@ -66,7 +66,7 @@ const {
 } = program;
 
 if (filter && fs.existsSync(filter)) {
-  options.filter = require(filter); // eslint-disable-line global-require,import/no-dynamic-require
+  options.filter = require(path.resolve(filter)); // eslint-disable-line global-require,import/no-dynamic-require
 }
 
 if (baseArg && fs.existsSync(baseArg)) {


### PR DESCRIPTION
This patch fixes the command line `-f` option. Currently it doesn't work, reporting `could not find module`.

`require` uses a different CWD than `fs` operations. Therefore, `existsSync` will return `true`, but `require` will not be able to find the filter module. This patch uses an absolute file path for `require`, resolving this issue.