### PR TITLE
If plural not found, fallback to english and prevent exception

### DIFF
--- a/src/lib/plurals.js
+++ b/src/lib/plurals.js
@@ -665,6 +665,6 @@ module.exports = {
   },
   getRule(code) {
     const locale = code.replace('-', '_');
-    return this.rules[locale.toLowerCase()] || this.rules[locale.split('_')[0]];
+    return this.rules[locale.toLowerCase()] || this.rules[locale.split('_')[0]] || this.rules.en;
   },
 };


### PR DESCRIPTION
Hi thanks for the lib,

I think it would be better if the program didn't throw an exception if the plural for the language isn't found? I don't think this list contains all languages and users of my software can create a language name with free type e.g. elvish.

Thanks