### PR TITLE
fix nplurals=1

### DIFF
--- a/src/lib/flatten.js
+++ b/src/lib/flatten.js
@@ -99,6 +99,11 @@ module.exports = {
       const kv = flat[m];
 
       if (kv.isPlural) {
+        if (!flat[kv.key + kv.context]) {
+          flat[kv.key + kv.context] = {
+            key: kv.key,
+          };
+        }
         const single = flat[kv.key + kv.context];
 
         if (single) {

--- a/src/lib/flatten.js
+++ b/src/lib/flatten.js
@@ -102,6 +102,7 @@ module.exports = {
         if (!flat[kv.key + kv.context]) {
           flat[kv.key + kv.context] = {
             key: kv.key,
+            context: kv.context,
           };
         }
         const single = flat[kv.key + kv.context];

--- a/src/lib/gettext2json.js
+++ b/src/lib/gettext2json.js
@@ -127,8 +127,6 @@ function parseJSON(locale, data = {}, options = {}) {
 
       if (m !== '' && !options.ignoreCtx) targetKey = `${targetKey}${ctxSeparator}${m}`;
 
-      const values = context[key].msgstr;
-
       if (options.persistMsgIdPlural) {
         // eslint-disable-next-line camelcase
         const { msgid, msgid_plural } = context[key];
@@ -137,7 +135,7 @@ function parseJSON(locale, data = {}, options = {}) {
         if (msgid_plural && msgid !== msgid_plural) targetKey = `${msgid}|#|${msgid_plural}`;
       }
 
-      const newValues = getGettextValues(values, locale, targetKey, options);
+      const newValues = getGettextValues(context[key], locale, targetKey, options);
 
       Object.assign(appendTo, newValues);
     });
@@ -146,8 +144,10 @@ function parseJSON(locale, data = {}, options = {}) {
   return Promise.resolve(json);
 }
 
-function getGettextValues(values, locale, targetKey, options) {
-  if (values.length === 1) {
+function getGettextValues(value, locale, targetKey, options) {
+  const values = value.msgstr;
+  const isPlural = !!value.msgid_plural;
+  if (!isPlural) {
     return emptyOrObject(targetKey, values[0], options);
   }
 

--- a/src/lib/json2gettext.js
+++ b/src/lib/json2gettext.js
@@ -122,11 +122,13 @@ function parseGettext(locale, data, options = {}) {
           plural.value,
         );
       }
-      pArray.splice(
-        getGettextPluralPosition(ext, kv.pluralNumber - 1),
-        0,
-        kv.value,
-      );
+      if (ext.nplurals !== 1) {
+        pArray.splice(
+          getGettextPluralPosition(ext, kv.pluralNumber - 1),
+          0,
+          kv.value,
+        );
+      }
 
       if (typeof trans[kv.context] !== 'object') trans[kv.context] = {};
       if (options.keyasareference) {

--- a/test/_testfiles/ja/translation.utf8.json
+++ b/test/_testfiles/ja/translation.utf8.json
@@ -1,0 +1,8 @@
+{
+    "a": {
+        "apple_0": "私はリンゴを{count}個持っています"
+    },
+    "friend_0": "{count}人の友達",
+    "friend_male_0": "{count}人の友達",
+    "friend_female_0": "{count}人のガールフレンド"
+}

--- a/test/_testfiles/ja/translation.utf8.po
+++ b/test/_testfiles/ja/translation.utf8.po
@@ -1,0 +1,25 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: i18next-conv\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0\n"
+
+msgid "a##apple"
+msgid_plural "a##apple"
+msgstr[0] "私はリンゴを{count}個持っています"
+
+msgid "friend"
+msgid_plural "friend"
+msgstr[0] "{count}人の友達"
+
+msgctxt "male"
+msgid "friend"
+msgid_plural "friend"
+msgstr[0] "{count}人の友達"
+
+msgctxt "female"
+msgid "friend"
+msgid_plural "friend"
+msgstr[0] "{count}人のガールフレンド"

--- a/test/index.js
+++ b/test/index.js
@@ -63,6 +63,11 @@ const testFiles = {
     utf8_msgid_not_fully_translated_expected:
       './test/_testfiles/ru/translation.utf8_msgid_not_fully_translated.json',
   },
+
+  ja: {
+    utf8: './test/_testfiles/ja/translation.utf8.po',
+    utf8_expected: './test/_testfiles/ja/translation.utf8.json',
+  },
 };
 
 /**
@@ -124,6 +129,12 @@ describe('i18next-gettext-converter', () => {
         splitNewLine: true,
       }).then((result) => {
         const expected = requireTestFile(testFiles.ru.utf8_expected);
+        expect(JSON.parse(result)).to.deep.equal(expected);
+      }),
+      gettextToI18next('ja', readFileSync(testFiles.ja.utf8), {
+        splitNewLine: true,
+      }).then((result) => {
+        const expected = requireTestFile(testFiles.ja.utf8_expected);
         expect(JSON.parse(result)).to.deep.equal(expected);
       }),
     ]));
@@ -296,6 +307,13 @@ describe('i18next-gettext-converter', () => {
       }).then((result) => {
         const expected = readFileSync(testFiles.ru.utf8_2).slice(0, -1); // TODO: figure out last character
         expect(result).to.deep.equal(expected);
+      }),
+      i18nextToPo('ja', readFileSync(testFiles.ja.utf8_expected), {
+        splitNewLine: true,
+        noDate: true,
+      }).then((result) => {
+        const expected = readFileSync(testFiles.ja.utf8).slice(0, -1); // TODO: figure out last character
+        expect(result.toString()).to.deep.equal(expected.toString());
       }),
     ]));
 


### PR DESCRIPTION
fix for languages with nplurals=1

correct formatting:
msgid "{{count}} apple"
msgid_plural "{{count}} apples"
msgstr[0] "{{count}}つのリンゴ"

current behavior:

msgid "{{count}} apple"
msgstr "{{count}} apples"