### PR TITLE
Add foldLength option

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ program
 .option('--splitNewLine', 'Silence output', false)
 .option('--ctxSeparator [sep]', 'Specify the context separator', '_')
 .option('--ignorePlurals', 'Do not process the plurals')
+.option('--foldLength', 'Specify the character fold length for strings', 76)
 .parse(process.argv);
 ```
 

--- a/bin/index.js
+++ b/bin/index.js
@@ -56,6 +56,7 @@ program
   .option('--splitNewLine', 'Silence output', false)
   .option('--ctxSeparator [sep]', 'Specify the context separator', '_')
   .option('--ignorePlurals', 'Do not process the plurals')
+  .option('--foldLength', 'Specify the character fold length for strings')
   .parse(process.argv);
 
 const {

--- a/lib/json2gettext.js
+++ b/lib/json2gettext.js
@@ -24,6 +24,10 @@ function i18nextToGettext(
   getTranslatedValue,
   options = {},
 ) {
+  const parserOptions = {};
+  if (options.foldLength !== undefined) {
+    parserOptions.foldLength = options.foldLength;
+  }
   return Promise.resolve(flatten(JSON.parse(body), options))
     .then((flat) => {
       if (options.base) {
@@ -45,7 +49,7 @@ function i18nextToGettext(
 
       return parseGettext(locale, flat, options);
     })
-    .then((data) => parser.compile(data));
+    .then((data) => parser.compile(data, parserOptions));
 }
 
 function getPluralArray(locale, translation) {

--- a/test/_testfiles/en/translation.foldLength.json
+++ b/test/_testfiles/en/translation.foldLength.json
@@ -1,0 +1,3 @@
+{
+    "The dog stole the apple and buried it in the yard. The next year, a tree started to grow.": "The dog stole the apple and buried it in the yard. The next year, a tree started to grow."
+}

--- a/test/_testfiles/en/translation.noFoldLength.po
+++ b/test/_testfiles/en/translation.noFoldLength.po
@@ -1,0 +1,5 @@
+msgid ""
+msgstr "Project-Id-Version: i18next-conv\nmime-version: 1.0\nContent-Type: text/plain; charset=utf-8\nContent-Transfer-Encoding: 8bit\nPlural-Forms: nplurals=2; plural=(n != 1)\n"
+
+msgid "The dog stole the apple and buried it in the yard. The next year, a tree started to grow."
+msgstr "The dog stole the apple and buried it in the yard. The next year, a tree started to grow."

--- a/test/index.js
+++ b/test/index.js
@@ -40,6 +40,9 @@ const testFiles = {
       './test/_testfiles/en/translation.persist-msgid_plural.json',
     persist_plural_id_po:
       './test/_testfiles/en/translation.persist-msgid_plural.po',
+    fold_length: './test/_testfiles/en/translation.foldLength.json',
+    no_fold_length_po:
+      './test/_testfiles/en/translation.noFoldLength.po'
   },
 
   de: {
@@ -262,6 +265,13 @@ describe('i18next-gettext-converter', () => {
         keyasareference: true,
       })).to.become(readFileSync(testFiles.de.utf8_msgid).slice(0, -1)),
     ]));
+
+    it('should change the fold length when a foldLength option is supplied', () =>
+      expect(i18nextToPo('en', readFileSync(testFiles.en.fold_length), {
+        splitNewLine: true,
+        foldLength: 0,
+        noDate: true,
+      })).to.become(readFileSync(testFiles.en.no_fold_length_po)));
 
     it('should convert a JSON file to utf8 MO', () =>
       expect(i18nextToMo('en', readFileSync(testFiles.en.utf8_expected), {


### PR DESCRIPTION
I added a foldLength option so users can control the third-party parser line wrap. I also added a test and documentation. Existing tests pass correctly.

Fixes https://github.com/i18next/i18next-gettext-converter/issues/81.

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included
- [x] documentation is changed or added