### PR TITLE
recognize nested object arrays and handle appropriately

### DIFF
--- a/lib/flatten.js
+++ b/lib/flatten.js
@@ -76,16 +76,20 @@ module.exports = {
           };
           appendTo[appendKey] = kv;
         } else if (Array.isArray(value)) {
-          kv = {
-            // id: key.replace(new RegExp(' ', 'g'), ''),
-            key,
-            value: value.join('\n'),
-            isArray: true,
-            isPlural,
-            pluralNumber: isPlural ? number : 0,
-            context,
-          };
-          appendTo[appendKey] = kv;
+          if (value.length > 0 && typeof value[0] === "object") {
+            recurse(appendTo, value, key);
+          } else {
+            kv = {
+              // id: key.replace(new RegExp(' ', 'g'), ''),
+              key,
+              value: value.join('\n'),
+              isArray: true,
+              isPlural,
+              pluralNumber: isPlural ? number : 0,
+              context,
+            };
+            appendTo[appendKey] = kv;
+          }
         } else {
           recurse(appendTo, value, key);
         }

--- a/test/_testfiles/en/translation.nested_array_of_objects.json
+++ b/test/_testfiles/en/translation.nested_array_of_objects.json
@@ -1,0 +1,10 @@
+{
+  "parent": {
+    "questions": [
+      {
+        "title": "test question",
+        "answer": "test answer"
+      }
+    ]
+  }
+}

--- a/test/_testfiles/en/translation.nested_array_of_objects.po
+++ b/test/_testfiles/en/translation.nested_array_of_objects.po
@@ -1,0 +1,16 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: i18next-conv\n"
+"mime-version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1)\n"
+"POT-Creation-Date: 2021-04-13T17:16:37.311Z\n"
+"PO-Revision-Date: 2021-04-13T17:16:37.311Z\n"
+"Language: en\n"
+
+msgid "parent##questions##0##title"
+msgstr "test question"
+
+msgid "parent##questions##0##answer"
+msgstr "test answer"

--- a/test/index.js
+++ b/test/index.js
@@ -42,7 +42,11 @@ const testFiles = {
       './test/_testfiles/en/translation.persist-msgid_plural.po',
     fold_length: './test/_testfiles/en/translation.foldLength.json',
     no_fold_length_po:
-      './test/_testfiles/en/translation.noFoldLength.po'
+      './test/_testfiles/en/translation.noFoldLength.po',
+    nested_array_of_objects_json:
+      './test/_testfiles/en/translation.nested_array_of_objects.json',
+    nested_array_of_objects_po:
+      './test/_testfiles/en/translation.nested_array_of_objects.po'
   },
 
   de: {
@@ -288,6 +292,13 @@ describe('i18next-gettext-converter', () => {
         'Plural-Forms: nplurals=4; plural=(n===1 ? 0 : n===2 ? 1 : (n<0 || n>10) &&  n%10==0 ? 2 : 3)',
       );
     }));
+
+    it('should recognize nested object arrays and recurse through them', () => {
+      expect(i18nextToPo('en', readFileSync(testFiles.en.nested_array_of_objects_json), {
+        splitNewLine: false,
+        noDate: true,
+      })).to.become(readFileSync(testFiles.en.nested_array_of_objects_po).slice(0, -1));
+    });
 
     describe('should return the correct plural forms for Portuguese', () => {
       [


### PR DESCRIPTION
The key

  { "test": { array: [{ inner1: "testing" }]}}

should become:

  msgid "test##array##inner1"
  msgstr "testing"

Before this patch, it resulted in:

  msgid "test##array"
  msgstr "[object Object]"

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

#### Checklist

- [X] only relevant code is changed (make a diff before you submit the PR)
- [X] run tests `npm run test`
- [X] tests are included
- [ ] documentation is changed or added