### PR TITLE
fix: get cli options via commander

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -68,7 +68,7 @@ const {
   filter,
   base: baseArg,
   ...options
-} = program;
+} = program.opts();
 
 if (filter && existsSync(filter)) {
   options.filter = require(path.resolve(filter)); // eslint-disable-line global-require,import/no-dynamic-require


### PR DESCRIPTION
Commander has been updated 10 days ago via [this commit](https://github.com/i18next/i18next-gettext-converter/commit/57f94fa1c8716aa8355200e39151fb5d78f6467d).

With this update, the cli doesn't work anymore, because from the [commander doc](https://github.com/tj/commander.js#options), the options values are now available via `program.opts()`. 

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [ ] run tests `npm run test` --> no test on cli
- [ ] tests are included --> not added a cli test strategy/structure, sorry, lack of time and this would take more time than just add a test :/

#### Checklist (for documentation change)

- [ ] only relevant documentation part is changed (make a diff before you submit the PR)
- [ ] motivation/reason is provided