### PR TITLE
No error thrown when error in .po file.

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -106,12 +106,12 @@ if (source && language) {
     })
     .catch((/* err */) => {
       console.log(red('failed writing file'));
-      process.exitCode = 1
+      process.exitCode = 1;
     });
 } else {
   console.log(red('at least call with argument -l and -s.'));
   console.log('(call program with argument -h for help.)');
-  process.exitCode = 1
+  process.exitCode = 1;
 }
 
 function processFile(locale, source, target, options) {
@@ -167,11 +167,11 @@ function processFile(locale, source, target, options) {
       return writeFile(target, data);
     })
     .catch((err) => {
-      if (err.code === 'ENOENT'){
+      if (err.code === 'ENOENT') {
         console.log(red(`file ${source} was not found.`));
       } else {
         console.log(red(err.message));
       }
-      throw err
+      throw err;
     });
 }

--- a/bin/index.js
+++ b/bin/index.js
@@ -88,7 +88,7 @@ if (source && language) {
   if (pot && !base) {
     console.log(red('at least call with argument -p and -b.'));
     console.log('(call program with argument -h for help.)');
-    process.exit(1);
+    process.exit(1); // eslint-disable-line no-process-exit
   }
 
   if (!options.quiet) console.log(yellow('start converting'));
@@ -104,7 +104,7 @@ if (source && language) {
     .then(() => {
       if (!options.quiet) console.log(green('file written'));
     })
-    .catch((err) => {
+    .catch((/* err */) => {
       console.log(red('failed writing file'));
       process.exitCode = 1
     });
@@ -117,18 +117,11 @@ if (source && language) {
 function processFile(locale, source, target, options) {
   if (!options.quiet) console.log((`--> reading file from: ${source}`));
 
-  return readFileAsync(source)
+  return readFile(source)
     .then((body) => {
       const dirname = path.dirname(source);
       const ext = path.extname(source);
       const filename = path.basename(source, ext);
-
-      if (options.plurals) {
-        const pluralsPath = path.join(process.cwd(), options.plurals);
-        plurals.rules = require(pluralsPath); // eslint-disable-line global-require,import/no-dynamic-require
-
-        if (!options.quiet) console.log(blue(`use custom plural forms ${pluralsPath}`));
-      }
 
       let targetDir;
       let targetExt;
@@ -181,10 +174,4 @@ function processFile(locale, source, target, options) {
       }
       throw err
     });
-}
-
-function writeFile(target, data, options = {}) {
-  if (!options.quiet) console.log((`<-- writing file to: ${target}`));
-
-  return writeFileAsync(target, data);
 }


### PR DESCRIPTION
When there is an issue in a translated .po file, the error isn't thrown
and no information is logged about the error. This will throw the error,
log it, and raise and exit code 1.

Closes #147 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included

> **No new test needed as there is already a test dedicated to throwing the same error**

#### Checklist (for documentation change)

- [x] only relevant documentation part is changed (make a diff before you submit the PR)
- [x] motivation/reason is provided