### PR TITLE
deps: migrate 'node-gettext' v3 to '@postalsys/gettext' v4

### DIFF
--- a/lib/gettext2json.js
+++ b/lib/gettext2json.js
@@ -1,4 +1,4 @@
-import Gettext from 'node-gettext';
+import Gettext from '@postalsys/gettext';
 import { po } from 'gettext-parser';
 import { js2i18next } from 'gettext-converter';
 import fromCallback from 'p-from-callback';

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,12 +9,12 @@
       "version": "15.0.0",
       "license": "SEE LICENSE IN LICENSE.MD",
       "dependencies": {
+        "@postalsys/gettext": "^4.0.0",
         "c8": "^10.1.2",
         "colorette": "^2.0.20",
         "commander": "^12.1.0",
         "gettext-converter": "^1.3.0",
         "gettext-parser": "^8.0.0",
-        "node-gettext": "^3.0.0",
         "p-from-callback": "^2.0.0"
       },
       "bin": {
@@ -425,6 +425,14 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@postalsys/gettext": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@postalsys/gettext/-/gettext-4.0.1.tgz",
+      "integrity": "sha512-QERj2sCJTZJN4scplV9BUpZObUsB/ZAF+/MD3OBxDkqTWEmK/C0HX1i15IRJ0YpYtl3hovc4mEN37HIGvb4pbw==",
+      "dependencies": {
+        "lodash.get": "4.4.2"
       }
     },
     "node_modules/@rtsao/scc": {
@@ -3453,14 +3461,6 @@
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
-    "node_modules/node-gettext": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/node-gettext/-/node-gettext-3.0.0.tgz",
-      "integrity": "sha512-/VRYibXmVoN6tnSAY2JWhNRhWYJ8Cd844jrZU/DwLVoI4vBI6ceYbd8i42sYZ9uOgDH3S7vslIKOWV/ZrT2YBA==",
-      "dependencies": {
-        "lodash.get": "^4.4.2"
-      }
-    },
     "node_modules/node-releases": {
       "version": "2.0.18",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.18.tgz",
@@ -5169,6 +5169,14 @@
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
       "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
       "optional": true
+    },
+    "@postalsys/gettext": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@postalsys/gettext/-/gettext-4.0.1.tgz",
+      "integrity": "sha512-QERj2sCJTZJN4scplV9BUpZObUsB/ZAF+/MD3OBxDkqTWEmK/C0HX1i15IRJ0YpYtl3hovc4mEN37HIGvb4pbw==",
+      "requires": {
+        "lodash.get": "4.4.2"
+      }
     },
     "@rtsao/scc": {
       "version": "1.1.0",
@@ -7289,14 +7297,6 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
-    },
-    "node-gettext": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/node-gettext/-/node-gettext-3.0.0.tgz",
-      "integrity": "sha512-/VRYibXmVoN6tnSAY2JWhNRhWYJ8Cd844jrZU/DwLVoI4vBI6ceYbd8i42sYZ9uOgDH3S7vslIKOWV/ZrT2YBA==",
-      "requires": {
-        "lodash.get": "^4.4.2"
-      }
     },
     "node-releases": {
       "version": "2.0.18",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "commander": "^12.1.0",
     "gettext-converter": "^1.3.0",
     "gettext-parser": "^8.0.0",
-    "node-gettext": "^3.0.0",
+    "@postalsys/gettext": "^4.0.0",
     "p-from-callback": "^2.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
To resolve [CVE-2024-21528](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-21528) (aka [`GHSA-g974-hxvm-x689`](https://github.com/advisories/GHSA-g974-hxvm-x689)), a prototype pollution vulnerability in the `addTranslations` function of `node-gettext`, migrate to `@postalsys/gettext` that includes a [fix](https://github.com/postalsys/gettext/commit/63e627cece1592d03abadf36044c957b801c7315) (and [followup adjustment](https://github.com/postalsys/gettext/commit/c2bf8dc8266e2eca748324bb2fc22a24f03beade)) for that specific problem.

I believe the API between v3.0.0 of `node-gettext` and v4.0.1 of `@postalsys/gettext`, both as published on NPM, is compatible.  A GitHub comparison URL for their code sources is: https://github.com/alexanderwallin/node-gettext/compare/v3.0.0...postalsys:gettext:v4.0.1

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [ ] tests are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)