### PR TITLE
Do not require -l if -t is present

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -61,7 +61,7 @@ if (base && existsSync(base)) {
   options.base = await readFile(base);
 }
 
-if (source && options.language) {
+if (source && (options.language || target)) {
   if (options.pot && !options.base) {
     console.log(red('at least call with argument -p and -b.'));
     console.log('(call program with argument -h for help.)');


### PR DESCRIPTION
When converting from .po to .json, you currently get an error if specifiying -s and -t but not the -l argument on the command line. However, -l is only used to build the path for the target and not present in the json output, so should not be required if -t is explicitly specified.

This updates the logic to require -s and -t OR -l.